### PR TITLE
OPS-7058 - create user and group "greenlight", chown dir /usr/src/app to greenlight user and run as this user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN apk update \
 
 FROM base as prod
 
+RUN addgroup -S -g 1000 greenlight && adduser -S -G greenlight -u 999 greenlight
+
 ARG PACKAGES='libpq-dev tzdata imagemagick yarn bash'
 COPY --from=build $RAILS_ROOT/vendor/bundle ./vendor/bundle
 COPY package.json yarn.lock ./
@@ -41,6 +43,10 @@ COPY . ./
 RUN apk update \
     && apk upgrade \
     && update-ca-certificates
+
+RUN chown -R greenlight /usr/src/app
+
+USER 999
 
 EXPOSE ${PORT}
 ENTRYPOINT [ "./bin/start" ]


### PR DESCRIPTION
[OPS-7058](https://ticketsystem.dbildungscloud.de/browse/OPS-7058)

Greenlight can be run as user greenlight (999) group greenlight (1000) with changes taken from
this [commit](https://github.com/bigbluebutton/greenlight/commit/ba14c234660f1ed4871bdd41b4ef5fa9f8766478) in the bigbluebutton/greenlight Github repo.

Note that this is a commit to revert the changes that we want, so they must've had some issue with the change.

However if we change
`RUN chown -R greenlight /usr/src/app/tmp`
to
`RUN chown -R greenlight /usr/src/app`

then the change appears to work fine